### PR TITLE
Allow Qt5 port to compile and run under Linux

### DIFF
--- a/src/LibGens/MathGens.h
+++ b/src/LibGens/MathGens.h
@@ -26,6 +26,8 @@ THE SOFTWARE.
 -----------------------------------------------------------------------------
 */
 
+#include <cmath>
+
 //=========================================================================
 //	Most of this code has been copied and modified from the Ogre3D Project.
 //=========================================================================
@@ -248,7 +250,7 @@ namespace LibGens {
 				return *this;
 			}
 
-			Quaternion Quaternion::operator* (const Quaternion& rkQ) {
+                        Quaternion operator* (const Quaternion& rkQ) {
 				return Quaternion
 				(
 					w * rkQ.w - x * rkQ.x - y * rkQ.y - z * rkQ.z,
@@ -441,7 +443,7 @@ namespace LibGens {
 			}
 
 			Color(Color8 col) {
-				Color::Color((unsigned char *) &col);
+                               Color((unsigned char *) &col);
 			}
 
 			inline bool operator == (const Color& color) {

--- a/src/LibGens/stdafx.h
+++ b/src/LibGens/stdafx.h
@@ -30,8 +30,10 @@ using namespace std;
 #include <pthread.h>
 #include "allegro5/allegro.h"
 #include "allegro5/allegro_image.h"
+#if defined(_WIN32) || defined(WIN32)
 #include <fbxsdk.h>
 #include <fbxsdk/fileio/fbxiosettings.h>
+#endif
 
 // Common Headers only should be pre-compiled
 #include "half/half.h"

--- a/src/SonicGLvl-qt/OgreCommon.h
+++ b/src/SonicGLvl-qt/OgreCommon.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
-#include <Ogre.h>
-#include <OgreRenderWindow.h>
-#include <OgreCamera.h>
-#include <OgreResourceManager.h>
-#include <OgreResourceGroupManager.h>
-#include <OgreSceneManager.h>
+#include <OGRE/Ogre.h>
+#include <OGRE/OgreRenderWindow.h>
+#include <OGRE/OgreCamera.h>
+#include <OGRE/OgreResourceManager.h>
+#include <OGRE/OgreResourceGroupManager.h>
+#include <OGRE/OgreSceneManager.h>
 

--- a/src/SonicGLvl-qt/OgreSystem.h
+++ b/src/SonicGLvl-qt/OgreSystem.h
@@ -29,6 +29,7 @@ public:
     OgreSystem();
     ~OgreSystem();
 
+    Ogre::RenderSystem *loadRenderSystem(const std::string systemName);
     Ogre::SceneManager *createSceneManager();
     Ogre::Root *getRoot();
     void setupResources();

--- a/src/SonicGLvl-qt/OgreViewportWidget.h
+++ b/src/SonicGLvl-qt/OgreViewportWidget.h
@@ -45,5 +45,5 @@ public:
     void moveAndResize();
     void createCamera(Ogre::String viewport_name);
     void createViewport();
-    QPaintEngine *OgreViewportWidget::paintEngine() const;
+    QPaintEngine *paintEngine() const;
 };

--- a/src/SonicGLvl-qt/SonicGLvl-qt.pro
+++ b/src/SonicGLvl-qt/SonicGLvl-qt.pro
@@ -43,17 +43,18 @@ HEADERS  += EditorWindow.h \
 
 FORMS    += EditorWindow.ui
 
-INCLUDEPATH += ../../depends/ogre/include \
-               ../../depends/ogre/include/OGRE \
-               ../../depends/ogre/boost \
-               ../../depends/pthreads/include \
-               ../../depends/allegro/include \
-               ../../depends/fbxsdk/include \
+INCLUDEPATH += ../../depends/fbxsdk/include \
                ../LibGens \
                ../LibGens-externals
 
+win32 {
+    INCLUDEPATH += ../../depends/ogre/include \
+                   ../../depends/ogre/boost \
+                   ../../depends/pthreads/include \
+                   ../../depends/allegro/include
+}
 
-LIBS += -L../../depends/ogre/lib/Release -lOgreMain
+LIBS += -L../../depends/ogre/lib/Release -lOgreMain -lboost_system
 
 QMAKE_LIBDIR += ../../depends/ogre/boost/lib
 


### PR DESCRIPTION
Few changes to allow current version of Qt5 port to compile with GCC on Linux with system-installed dependent headers and libs (OGRE, pthreads, Allegro, Boost C++). 
OgreSystem now tries to load OpenGL rendering subsystem in case loading Direct3D9 one fails. 