### PR TITLE
Fix the example that was given

### DIFF
--- a/bin/modelfbx-convert-example.bat
+++ b/bin/modelfbx-convert-example.bat
@@ -1,1 +1,1 @@
-for %%f in (Sonic.ar/*.anm.hkx) do modelfbx Sonic/chr_Sonic_HD.skl.hkx Sonic/%%f Sonic/%%f.fbx
+for %%f in (Sonic/*.anm.hkx) do modelfbx Sonic/chr_Sonic_HD.model Sonic/chr_Sonic_HD.skl.hkx Sonic/%%f Sonic/%%f.fbx


### PR DESCRIPTION
Before, the example looked in a different spot for the animations (Sonic.ar), and didn't grab the model file in that folder. It was edited so it now grabs animation files from the correct folder (Sonic) and the model file.